### PR TITLE
Open /dev/tty instead of stdin for reading code

### DIFF
--- a/cli/assume-role/main.go
+++ b/cli/assume-role/main.go
@@ -16,11 +16,17 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/uber/assume-role-cli/cli"
 )
 
 func main() {
-	os.Exit(cli.Main(os.Stdin, os.Stdout, os.Stderr, os.Args[1:]))
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(cli.Main(tty, os.Stdout, os.Stderr, os.Args[1:]))
 }


### PR DESCRIPTION
Previously, we were opening stdin for reading the MFA code. However,
this causes an issue when we want to use stdin for something else, e.g.
as a git helper (see #4).

Instead, we open the current terminal at /dev/tty.

Fixes #4.