### PR TITLE
travis: skip integration tests for tests running on PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 - vendor
 script:
 - make lint
-- go test -v ./...
+- ./run-tests.sh
 env:
   global:
   - secure: MTgowTKGnUpre8ZL4oBcBtU0dRp3ntBET3u9XoLOby6PQ6mPn3GTDhb/drSVC0n70MBY/+i7zsUMYESHBZSFMP4KPYBOP5miTXZ8ujl65BaXW3Z5kyi+nCuxNQS1jaFYH3a46YbOrEtkc/q2PRvy8+oCx7sj1cpFDv11sTN5T6an0YtOJgYtu+QCK5IuNziGn35ZVhZS116KcOfvoN6LacwWrXGzDbbzPYrty7kjPRKWe0A9EiaUIvQdqcQ6Syfq99lfP3YFamXdqFRGE/ardwGfbjR+Lsv9pP3ACP3uPLDVEsGBO0doIvGT/00ZHfQaQQ24YKMF2an89RGJMmolmAbNkkSo0dUAJIhx5SUGQkS1ysMFPyVNOebN5B7xYce9xyFjuN8Ch8MK8rBbsXuNYDUkIt9u5Ir0B/uYExamHSb7ok2Y+h533ZEkFthWrCI31v7zK5o+6CJe4xMDE7A21GcQiBqbISOzde+6WOiLg89FS7pIYcdP6o/e6entAxU9CVx1VcH3fwQ5fmFPiL030BoVJUuecS9tjTX7eMFGbLgRGq/rtDysaZ5Z79ZSsQuFO9rAMa5cC52bOTlojzjSroLdQxfBy/16ICqFJY9z+s7v+Y5TBNgtpaiI6s/5wBN+vDJFKI4itAZr5iaqfMWbMLF4gYmKavbke/MoelocXSw=

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ev
+
+# Encrypted env variables are not present in PRs generated
+# from forks and therefore the tests will always fail.
+# As the tests that need encrypted env variables are only
+# integration tests, they can be skipped with short (-s) flag.
+if [ "${TRAVIS_SECURE_ENV_VARS}" = "false" ]; then
+    go test -v -short ./...
+else
+    go test -v ./...
+fi


### PR DESCRIPTION
The PRs from forks do not contain encrypted environment variables, therefore we cannot run the integration tests. This PR will ensure that the builds for such PRs run tests with short flag (without integration tests).

Fixes #8 
