### PR TITLE
Introduce --force-refresh flag to refresh the credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0 (UNRELEASED, 2019)
+
+* Introduce --force-refresh flag to bypass and refresh the cache
+
 ## 1.0.0 (October 5, 2018)
 
 * Initial public release

--- a/app.go
+++ b/app.go
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-// Package assumerole contains main application logic
+// Package assumerole is a wrapper around AWS's sts:AssumeRole API call
+// to get temporary credentials and cache them locally in ~/.aws config files.
 package assumerole
 
 import (
@@ -46,8 +47,8 @@ type App struct {
 	stdinReader *bufio.Reader
 }
 
-// Parameters are the parameters for the AssumeRole call
-type Parameters struct {
+// AssumeRoleParameters are the parameters for the AssumeRole call
+type AssumeRoleParameters struct {
 	// UserRole is the ARN of the role to be assumed
 	UserRole string
 
@@ -55,7 +56,8 @@ type Parameters struct {
 	// the empty string, the current username will be used
 	RoleSessionName string
 
-	// Force refresh forces credential refresh
+	// When ForceRefresh is true, assumerole will bypass the local cache and do a
+	// call to sts:AssumeRole to retrieve fresh credentials.
 	ForceRefresh bool
 }
 
@@ -85,7 +87,7 @@ func NewApp(opts ...Option) (*App, error) {
 // AssumeRole takes a role name and calls AWS AssumeRole, returning a
 // set of temporary credentials. If MFA is required, it will prompt for
 // an MFA token interactively.
-func (app *App) AssumeRole(options Parameters) (*TemporaryCredentials, error) {
+func (app *App) AssumeRole(options AssumeRoleParameters) (*TemporaryCredentials, error) {
 	profileName, err := app.profileName(options.UserRole)
 	if err != nil {
 		return nil, err

--- a/app_test.go
+++ b/app_test.go
@@ -124,7 +124,7 @@ func TestAssumeRoleWithMFAFirstTime(t *testing.T) {
 
 	test.MockStdin.WriteString("123456" + "\n")
 
-	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.Parameters{
+	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.AssumeRoleParameters{
 		UserRole: fooProfileWithMFA.RoleARN,
 	})
 	assert.NoError(t, err)
@@ -146,7 +146,7 @@ func TestErrorNoMFADevices(t *testing.T) {
 
 	test.MockStdin.WriteString("123456" + "\n")
 
-	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.Parameters{
+	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.AssumeRoleParameters{
 		UserRole: fooProfileWithMFA.RoleARN,
 	})
 	require.Error(t, err)
@@ -179,7 +179,7 @@ func TestMFAPromptInvalid(t *testing.T) {
 	test.MockStdin.WriteString("1\n")
 	test.MockStdin.WriteString("123456\n")
 
-	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.Parameters{
+	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.AssumeRoleParameters{
 		UserRole: "arn:aws:iam::000000000000:role/testRole",
 	})
 	require.NoError(t, err)
@@ -206,7 +206,7 @@ func TestAssumeRoleWithAssumedRoleSuccess(t *testing.T) {
 	test.MockAWSConfig.EXPECT().SetProfile("000000000000-testRole-fromassumedrole", fooProfileWithoutMFA).Return(nil)
 	test.MockAWSConfig.EXPECT().SetCredentials("000000000000-testRole-fromassumedrole", fooCredentials)
 
-	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.Parameters{
+	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.AssumeRoleParameters{
 		UserRole:        fooProfileWithoutMFA.RoleARN,
 		RoleSessionName: "bob-session",
 	})
@@ -222,7 +222,7 @@ func TestAssumeRoleWithAssumedRoleDoesNotTryMFA(t *testing.T) {
 
 	test.MockAWSConfig.EXPECT().GetProfile("000000000000-testRole-fromassumedrole").Return(nil, nil)
 
-	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.Parameters{
+	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.AssumeRoleParameters{
 		UserRole:        fooProfileWithoutMFA.RoleARN,
 		RoleSessionName: "bob-session",
 	})
@@ -248,7 +248,7 @@ func TestConfigRolePrefix(t *testing.T) {
 
 	test.MockStdin.WriteString("123456" + "\n")
 
-	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.Parameters{
+	creds, err := test.AssumeRoleMain.AssumeRole(assumerole.AssumeRoleParameters{
 		UserRole: "testRole",
 	})
 	assert.NoError(t, err)
@@ -338,7 +338,7 @@ func TestCredentialsExpiry(t *testing.T) {
 			test.MockAWSConfig.EXPECT().GetCredentials(gomock.Any()).Return(mockCreds, nil)
 		}
 
-		creds, err := test.AssumeRoleMain.AssumeRole(assumerole.Parameters{
+		creds, err := test.AssumeRoleMain.AssumeRole(assumerole.AssumeRoleParameters{
 			ForceRefresh: tt.forceRefresh,
 			UserRole:     "arn:aws:iam::123:role/testRole",
 		})

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Package cli is reponsible for cli interaction
 package cli
 
 import (
@@ -22,7 +24,7 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/uber/assume-role-cli"
+	assumerole "github.com/uber/assume-role-cli"
 )
 
 // credentialsToEnv takes credentials and outputs them as a list of environment
@@ -81,6 +83,7 @@ Usage:
 
 Options:
       --help                       Help for assume-role
+	  --force-refresh              Forces credentials refresh irrespective of their expiry
       --role string                Name of the role to assume
       --role-session-name string   Name of the session for the assumed role
 `)
@@ -111,7 +114,7 @@ func Main(stdin io.Reader, stdout io.Writer, stderr io.Writer, args []string) (e
 		return 1
 	}
 
-	credentials, err := app.AssumeRole(assumerole.AssumeRoleParameters{
+	credentials, err := app.AssumeRole(assumerole.Parameters{
 		UserRole:        userOpts.role,
 		RoleSessionName: userOpts.roleSessionName,
 	})

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -83,7 +83,7 @@ Usage:
 
 Options:
       --help                       Help for assume-role
-	  --force-refresh              Forces credentials refresh irrespective of their expiry
+      -f, --force-refresh          Forces credentials refresh irrespective of their expiry
       --role string                Name of the role to assume
       --role-session-name string   Name of the session for the assumed role
 `)
@@ -114,7 +114,7 @@ func Main(stdin io.Reader, stdout io.Writer, stderr io.Writer, args []string) (e
 		return 1
 	}
 
-	credentials, err := app.AssumeRole(assumerole.Parameters{
+	credentials, err := app.AssumeRole(assumerole.AssumeRoleParameters{
 		ForceRefresh:    userOpts.forceRefresh,
 		UserRole:        userOpts.role,
 		RoleSessionName: userOpts.roleSessionName,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -115,6 +115,7 @@ func Main(stdin io.Reader, stdout io.Writer, stderr io.Writer, args []string) (e
 	}
 
 	credentials, err := app.AssumeRole(assumerole.Parameters{
+		ForceRefresh:    userOpts.forceRefresh,
 		UserRole:        userOpts.role,
 		RoleSessionName: userOpts.roleSessionName,
 	})

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -85,7 +85,6 @@ func copyFilesToTempDir(src string) (string, error) {
 func makeFixtureDir(t *testing.T) string {
 	fixtureDir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(fixtureDir)
 	return fixtureDir
 }
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -305,8 +305,9 @@ func TestConfig(t *testing.T) {
 	defer os.RemoveAll(fixtureDir)
 
 	result := execTest(t, execTestOpts{
-		args:     []string{"--role", "test_assume-role"},
-		testType: WITHOUT_MFA,
+		args:       []string{"--role", "test_assume-role"},
+		fixtureDir: fixtureDir,
+		testType:   WITHOUT_MFA,
 	})
 	assert.Empty(t, result.Stderr.String())
 	assert.Zero(t, result.ExitCode)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -32,6 +32,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testType string
+
+const (
+	WITH_MFA    testType = "WITH_MFA"
+	WITHOUT_MFA testType = "WITHOUT_MFA"
+)
+
 // Env vars containing secret keys need to be set for some integration tests
 // to work properly. For security reasons, they are not committed to the repo.
 var secretCredentialsEnvVarPrefix = "ASSUME_ROLE_INTEGRATION_TEST_"
@@ -47,13 +54,9 @@ var secretOTPEnvVar = secretCredentialsEnvVarPrefix + "AWS_OTP_SECRET"
 type execTestOpts struct {
 	// Args to send to the program for the test.
 	args []string
-	// Additional env vars to set before executing the test.
-	env map[string]string
-	// Directory that contains the fixture data (e.g. aws config files).
-	// Test will be executed in this dir.
-	fixture string
 	// String value for stdin for the test.
-	input string
+	input    string
+	testType testType
 }
 
 type execResult struct {
@@ -87,15 +90,22 @@ func execTest(t *testing.T, opts execTestOpts) *execResult {
 	defer os.Setenv("AWS_SHARED_CREDENTIALS_FILE", oldAWSSharedCredsEnv)
 
 	// Set additional env vars
-	for key, val := range opts.env {
+	env, err := readSecretCredentialsFromEnv(string(opts.testType))
+	require.NoError(t, err)
+
+	for key, val := range env {
 		oldValue := os.Getenv(key)
 		defer os.Setenv(key, oldValue)
 
 		os.Setenv(key, val)
 	}
 
-	os.Setenv("AWS_CONFIG_FILE", filepath.Join(opts.fixture, "aws/config"))
-	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(opts.fixture, "aws/credentials"))
+	fixtureDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(fixtureDir)
+
+	os.Setenv("AWS_CONFIG_FILE", filepath.Join(fixtureDir, "aws/config"))
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(fixtureDir, "aws/credentials"))
 
 	stdin := bytes.NewBufferString(opts.input)
 
@@ -103,12 +113,22 @@ func execTest(t *testing.T, opts execTestOpts) *execResult {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
-	err = os.Chdir(opts.fixture)
+	err = os.Chdir(fixtureDir)
 	require.NoError(t, err)
 
 	defer os.Chdir(cwd)
 
 	exitCode := cli.Main(stdin, stdout, stderr, opts.args)
+
+	writtenCredentialFile, err := os.Stat(filepath.Join(fixtureDir, "aws/credentials"))
+	require.NoError(t, err)
+
+	writtenConfigFile, err := os.Stat(filepath.Join(fixtureDir, "aws/config"))
+	require.NoError(t, err)
+
+	// Config/credential files should have been written to
+	assert.NotZero(t, writtenConfigFile.Size())
+	assert.NotZero(t, writtenCredentialFile.Size())
 
 	return &execResult{
 		ExitCode: exitCode,
@@ -146,17 +166,9 @@ func TestAssumeRoleWithoutMFA(t *testing.T) {
 		t.Skip("skipping integration test due to -short flag")
 	}
 
-	awsCreds, err := readSecretCredentialsFromEnv("WITHOUT_MFA")
-	require.NoError(t, err)
-
-	fixtureDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(fixtureDir)
-
 	result := execTest(t, execTestOpts{
-		args:    []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
-		env:     awsCreds,
-		fixture: fixtureDir,
+		args:     []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
+		testType: WITHOUT_MFA,
 	})
 	assert.Regexp(t, "^AWS_ACCESS_KEY_ID=.*\nAWS_SECRET_ACCESS_KEY=.*\nAWS_SESSION_TOKEN=.*\n$", result.Stdout.String())
 	assert.Empty(t, result.Stderr.String())
@@ -168,17 +180,9 @@ func TestErrorNoMFADevices(t *testing.T) {
 		t.Skip("skipping integration test due to -short flag")
 	}
 
-	awsCreds, err := readSecretCredentialsFromEnv("WITHOUT_MFA")
-	require.NoError(t, err)
-
-	fixtureDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(fixtureDir)
-
 	result := execTest(t, execTestOpts{
-		args:    []string{"--role", "arn:aws:iam::675470192105:role/no-access-role"},
-		env:     awsCreds,
-		fixture: fixtureDir,
+		args:     []string{"--role", "arn:aws:iam::675470192105:role/no-access-role"},
+		testType: WITHOUT_MFA,
 	})
 	assert.Contains(t, result.Stderr.String(), "error trying to AssumeRole without MFA")
 	assert.Contains(t, result.Stderr.String(), "error trying to AssumeRole with MFA")
@@ -190,18 +194,11 @@ func TestAssumeRoleWithMFA(t *testing.T) {
 		t.Skip("skipping integration test due to -short flag")
 	}
 
-	awsCreds, err := readSecretCredentialsFromEnv("WITH_MFA")
-	require.NoError(t, err)
-
 	otpSecret := os.Getenv(secretOTPEnvVar)
 	if otpSecret == "" {
 		t.Errorf("missing OTP secret from env var: %v", secretOTPEnvVar)
 		t.FailNow()
 	}
-
-	fixtureDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(fixtureDir)
 
 	mfa := otp.TOTP{
 		Secret:         otpSecret,
@@ -209,10 +206,9 @@ func TestAssumeRoleWithMFA(t *testing.T) {
 	}
 
 	result := execTest(t, execTestOpts{
-		args:    []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
-		env:     awsCreds,
-		fixture: fixtureDir,
-		input:   mfa.Get() + "\n",
+		args:     []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
+		input:    mfa.Get() + "\n",
+		testType: WITH_MFA,
 	})
 	assert.Regexp(t, "^AWS_ACCESS_KEY_ID=.*\nAWS_SECRET_ACCESS_KEY=.*\nAWS_SESSION_TOKEN=.*\n$", result.Stdout.String())
 	assert.Equal(t, "Enter MFA token: ", result.Stderr.String())
@@ -224,43 +220,49 @@ func TestCredentialsCached(t *testing.T) {
 		t.Skip("skipping integration test due to -short flag")
 	}
 
-	awsCreds, err := readSecretCredentialsFromEnv("WITHOUT_MFA")
-	require.NoError(t, err)
-
-	fixtureDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(fixtureDir)
-
 	// Do the first AssumeRole
 	a := execTest(t, execTestOpts{
-		args:    []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
-		env:     awsCreds,
-		fixture: fixtureDir,
+		args:     []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
+		testType: WITHOUT_MFA,
 	})
 	require.Empty(t, a.Stderr.String())
 	require.Zero(t, a.ExitCode)
 
 	// Do the second AssumeRole
 	b := execTest(t, execTestOpts{
-		args:    []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
-		env:     awsCreds,
-		fixture: fixtureDir,
+		args:     []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
+		testType: WITHOUT_MFA,
 	})
 	require.Empty(t, b.Stderr.String())
 	require.Zero(t, b.ExitCode)
 
 	// Credentials should match because they were cached the first time
 	assert.Equal(t, a.Stdout.String(), b.Stdout.String())
+}
 
-	writtenCredentialFile, err := os.Stat(filepath.Join(fixtureDir, "aws/credentials"))
-	require.NoError(t, err)
+func TestCredentialsCachedForceRefresh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test due to -short flag")
+	}
 
-	writtenConfigFile, err := os.Stat(filepath.Join(fixtureDir, "aws/config"))
-	require.NoError(t, err)
+	// Do the first AssumeRole
+	a := execTest(t, execTestOpts{
+		args:     []string{"--role", "arn:aws:iam::675470192105:role/test_assume-role"},
+		testType: WITHOUT_MFA,
+	})
+	require.Empty(t, a.Stderr.String())
+	require.Zero(t, a.ExitCode)
 
-	// Config/credential files should have been written to
-	assert.NotZero(t, writtenConfigFile.Size())
-	assert.NotZero(t, writtenCredentialFile.Size())
+	// Do the second AssumeRole
+	b := execTest(t, execTestOpts{
+		args:     []string{"--force-refresh", "--role", "arn:aws:iam::675470192105:role/test_assume-role"},
+		testType: WITHOUT_MFA,
+	})
+	require.Empty(t, b.Stderr.String())
+	require.Zero(t, b.ExitCode)
+
+	// Credentials not match because they were force refreshed
+	assert.Equal(t, a.Stdout.String(), b.Stdout.String())
 }
 
 func TestConfig(t *testing.T) {
@@ -268,17 +270,9 @@ func TestConfig(t *testing.T) {
 		t.Skip("skipping integration test due to -short flag")
 	}
 
-	awsCreds, err := readSecretCredentialsFromEnv("WITHOUT_MFA")
-	require.NoError(t, err)
-
-	fixtureDir, err := copyFilesToTempDir("fixtures/test-config")
-	require.NoError(t, err)
-	defer os.RemoveAll(fixtureDir)
-
 	result := execTest(t, execTestOpts{
-		args:    []string{"--role", "test_assume-role"},
-		fixture: fixtureDir,
-		env:     awsCreds,
+		args:     []string{"--role", "test_assume-role"},
+		testType: WITHOUT_MFA,
 	})
 	assert.Empty(t, result.Stderr.String())
 	assert.Zero(t, result.ExitCode)

--- a/cli/options.go
+++ b/cli/options.go
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Package cli is reponsible for cli interaction
 package cli
 
-import "errors"
+import (
+	"errors"
+)
 
 // cliOpts are the available options for the assume-role CLI.
 type cliOpts struct {
@@ -29,6 +33,9 @@ type cliOpts struct {
 
 	// roleSessionName overrides the default session name
 	roleSessionName string
+
+	// forceRefresh causes credentials to be refreshed irrespective of the expiry
+	forceRefresh bool
 }
 
 // argumentList is a special slice of strings that includes helpers for
@@ -60,6 +67,9 @@ func parseOptions(args argumentList) (*cliOpts, error) {
 ArgsLoop:
 	for len(args) > 0 {
 		switch arg := args.Next(); arg {
+
+		case "--force-refresh":
+			opts.forceRefresh = true
 
 		case "--role":
 			opts.role = args.Next()

--- a/cli/options.go
+++ b/cli/options.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// Package cli is reponsible for cli interaction
 package cli
 
 import (
@@ -67,6 +66,9 @@ func parseOptions(args argumentList) (*cliOpts, error) {
 ArgsLoop:
 	for len(args) > 0 {
 		switch arg := args.Next(); arg {
+
+		case "-f":
+			opts.forceRefresh = true
 
 		case "--force-refresh":
 			opts.forceRefresh = true

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -61,3 +61,12 @@ func TestParseOptionsForceRefresh(t *testing.T) {
 	assert.Equal(t, true, cliOpts.forceRefresh)
 	assert.Equal(t, []string{"ls", "-l"}, cliOpts.args)
 }
+
+func TestParseOptionsForceRefreshShort(t *testing.T) {
+	cliOpts, err := parseOptions([]string{"--role", testRole, "-f", "ls", "-l"})
+	assert.NoError(t, err)
+	assert.Equal(t, testRole, cliOpts.role)
+	assert.Equal(t, "", cliOpts.roleSessionName)
+	assert.Equal(t, true, cliOpts.forceRefresh)
+	assert.Equal(t, []string{"ls", "-l"}, cliOpts.args)
+}

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -52,3 +52,12 @@ func TestParseOptionsNoRole(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, errNoRole, err)
 }
+
+func TestParseOptionsForceRefresh(t *testing.T) {
+	cliOpts, err := parseOptions([]string{"--role", testRole, "--force-refresh", "ls", "-l"})
+	assert.NoError(t, err)
+	assert.Equal(t, testRole, cliOpts.role)
+	assert.Equal(t, "", cliOpts.roleSessionName)
+	assert.Equal(t, true, cliOpts.forceRefresh)
+	assert.Equal(t, []string{"ls", "-l"}, cliOpts.args)
+}


### PR DESCRIPTION
This will bypass and update the cache.

Also renamed `AssumeRoleParameters` to `Parameters` because my linter was complaining. It's a breaking change, but it's probably fine to do it now, while we're still early.

Also refactored tests a bit - I wanted to try and thought it would make sense, but then found myself in a hole and it doesn't look as good as I thought. 
It might actually be better (not sure), but can revert if you disagree - leaving changes here to get fierce feedback.

Fixes #10 