### PR TITLE
Add version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ clean-mocks:
 	rm mocks/*.go
 
 assume-role: vendor $(source_files)
-	go build -o assume-role ./cli/assume-role/main.go
+	go build \
+		-o assume-role \
+		-ldflags "-X github.com/uber/assume-role-cli/cli.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		./cli/assume-role/main.go
 
 .PHONY:
 lint: lint-license

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -82,10 +82,11 @@ Usage:
   assume-role [options] <command> [args ...]
 
 Options:
-      --help                       Help for assume-role
+      -h, --help                   Help for assume-role
       -f, --force-refresh          Forces credentials refresh irrespective of their expiry
       --role string                Name of the role to assume
       --role-session-name string   Name of the session for the assumed role
+      --version                    Print the version of assume-role-cli
 `)
 }
 
@@ -97,9 +98,14 @@ func printVars(vars []string, out io.Writer) {
 
 // Main is the main entry point into the CLI program.
 func Main(stdin io.Reader, stdout io.Writer, stderr io.Writer, args []string) (exitCode int) {
-	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help") {
-		printHelp(stdout)
-		return 0
+	if len(args) == 1 {
+		if args[0] == "-h" || args[0] == "--help" {
+			printHelp(stdout)
+			return 0
+		} else if args[0] == "--version" {
+			printVersion(stdout)
+			return 0
+		}
 	}
 
 	app, err := loadApp(stdin, stdout, stderr)

--- a/cli/version.go
+++ b/cli/version.go
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+)
+
+func printVersion(out io.Writer) {
+	fmt.Fprintln(out, strings.Join(getVersionComponents(), " "))
+}
+
+func getVersionComponents() []string {
+	ret := []string{
+		"assume-role version",
+		version,
+	}
+
+	if commit != "" {
+		ret = append(ret, fmt.Sprintf("(%s)", commit))
+	}
+
+	if date != "" {
+		ret = append(ret, "built", date)
+	}
+
+	return ret
+}


### PR DESCRIPTION
This adds a `--version` flag to assume-role so you can see which version you're running.