### PR TITLE
Set source_profile correctly

### DIFF
--- a/app.go
+++ b/app.go
@@ -101,6 +101,11 @@ func (app *App) AssumeRole(options AssumeRoleParameters) (*TemporaryCredentials,
 		profile = &ProfileConfiguration{}
 	}
 
+	profile.SourceProfile = os.Getenv("AWS_PROFILE")
+	if profile.SourceProfile == "" {
+		profile.SourceProfile = "default"
+	}
+
 	currentPrincipalIsAssumedRole, err := app.CurrentPrincipalIsAssumedRole()
 	if err != nil {
 		return nil, fmt.Errorf("unable to check IAM principal type: %v", err)

--- a/app_test.go
+++ b/app_test.go
@@ -45,12 +45,14 @@ var fooProfileWithMFA = &assumerole.ProfileConfiguration{
 	MFASerial:       "arn:aws:iam::000000000000:mfa/bob",
 	RoleARN:         "arn:aws:iam::000000000000:role/testRole",
 	RoleSessionName: "bob",
+	SourceProfile:   "default",
 }
 
 var fooProfileWithoutMFA = &assumerole.ProfileConfiguration{
 	Expires:         fooCredentials.Expires,
 	RoleARN:         "arn:aws:iam::000000000000:role/testRole-fromassumedrole",
 	RoleSessionName: "bob-session",
+	SourceProfile:   "default",
 }
 
 type test struct {


### PR DESCRIPTION
This fixes an issue where AWS CLI tools throw the error:

```
The source_profile "" referenced in the profile "foo" does not exist
```

This is caused when assume-role explicitly writes out an empty value as
`""`.